### PR TITLE
Add a one-command refresh against upstream MEOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ cgo_flag_config.go
 # provision-meos action (MEOS-API run.py), never committed. The flat FFI
 # functions package is projected from it and IS committed.
 tools/meos-idl.json
+
+# tools/refresh-from-master.sh scratch (sibling clones + libmeos prefix).
+.meos-chain/

--- a/tools/refresh-from-master.sh
+++ b/tools/refresh-from-master.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# refresh-from-master.sh — refresh this binding's generated surface against the latest MEOS API,
+# end to end, with one command:
+#
+#   tools/refresh-from-master.sh
+#
+# It runs the shared MobilityDB/MEOS-API refresh-binding.sh over this repo — deriving the catalog
+# and libmeos from the latest MobilityDB master and regenerating this binding's surface. The
+# per-binding last leg is in tools/refresh.conf.
+#
+# All of refresh-binding.sh's options pass through, e.g.:
+#   tools/refresh-from-master.sh --mdb ~/src/MobilityDB   # refresh against a local MobilityDB branch
+#   tools/refresh-from-master.sh --skip-tests             # regenerate + build, skip the tests
+#
+# MEOSAPI=<path> uses an existing MEOS-API checkout (any branch); otherwise MEOS-API master is
+# cloned into the work dir. WORK_DIR overrides the scratch location (default <repo>/.meos-chain).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="${WORK_DIR:-$HERE/.meos-chain}"
+MEOSAPI="${MEOSAPI:-}"
+
+if [ -z "$MEOSAPI" ]; then
+  MEOSAPI="$WORK/MEOS-API"
+  mkdir -p "$WORK"
+  if [ -d "$MEOSAPI/.git" ]; then
+    git -C "$MEOSAPI" fetch --quiet https://github.com/MobilityDB/MEOS-API master
+    git -C "$MEOSAPI" checkout --quiet FETCH_HEAD
+  else
+    git clone --quiet https://github.com/MobilityDB/MEOS-API "$MEOSAPI"
+  fi
+fi
+
+exec "$MEOSAPI/tools/refresh-binding.sh" \
+  --binding "$HERE" --meos-api "$MEOSAPI" --work-dir "$WORK" "$@"

--- a/tools/refresh.conf
+++ b/tools/refresh.conf
@@ -1,0 +1,12 @@
+# refresh.conf — GoMEOS's last leg for tools/refresh-binding.sh (in MEOS-API).
+# The chain (MobilityDB -> catalog + libmeos) is shared; only these differ per binding.
+# BUILD_CMD runs from <repo>/<BUILD_DIR> with $PREFIX (the libmeos install prefix) and $CATALOG
+# exported; $SKIP_TESTS is set when --skip-tests is passed. tools/codegen.py reads the catalog
+# staged at CATALOG_DEST and regenerates the committed functions/ package.
+ENGINE=go
+BUILD_DIR=.
+BUILD_LIBMEOS=true
+CATALOG_DEST=tools/meos-idl.json
+BUILD_CMD='python3 tools/codegen.py
+  CGO_CFLAGS="-I$PREFIX/include -I/usr/include/h3" CGO_LDFLAGS="-L$PREFIX/lib -lmeos" LD_LIBRARY_PATH="$PREFIX/lib" go build ./functions
+  [ -n "${SKIP_TESTS:-}" ] || CGO_ENABLED=0 go test ./tools/parity/'


### PR DESCRIPTION
`tools/refresh-from-master.sh` refreshes the generated `functions/` package against upstream MEOS in one command: it runs the shared MobilityDB/MEOS-API `refresh-binding.sh` over this repo, deriving the catalog and libmeos from MobilityDB master and regenerating the wrappers via `tools/codegen.py`. `tools/refresh.conf` holds this binding's last leg (the `go build`, with CGO/LD flags pointing at the derived libmeos prefix). `.gitignore` excludes the wrapper's `.meos-chain/` scratch. The wrapper and the `refresh.conf` shape are the same as every other MobilityDB binding.